### PR TITLE
Add receiver.stopListening, remove listeners from sender too

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ of transfers paying for the payment requests created by the Receiver.
     * [~getAddress()](#module_Receiver..createReceiver..getAddress) ⇒ <code>String</code>
     * [~createRequest()](#module_Receiver..createReceiver..createRequest) ⇒ <code>Object</code>
     * [~listen()](#module_Receiver..createReceiver..listen) ⇒ <code>Promise.&lt;null&gt;</code>
+    * [~stopListening()](#module_Receiver..createReceiver..stopListening) ⇒ <code>Promise.&lt;null&gt;</code>
 
 <a name="module_Receiver..createReceiver..getAddress"></a>
 
@@ -274,6 +275,13 @@ receiver created.
 **Kind**: inner method of <code>[createReceiver](#module_Receiver..createReceiver)</code>  
 **Returns**: <code>Promise.&lt;null&gt;</code> - Resolves when the receiver is connected  
 **Emits**: <code>[incoming](#event_incoming)</code>, <code>incoming:requestid</code>  
+<a name="module_Receiver..createReceiver..stopListening"></a>
+
+#### createReceiver~stopListening() ⇒ <code>Promise.&lt;null&gt;</code>
+Disconnect from the ledger and stop listening for events.
+
+**Kind**: inner method of <code>[createReceiver](#module_Receiver..createReceiver)</code>  
+**Returns**: <code>Promise.&lt;null&gt;</code> - Resolves when the receiver is disconnected.  
 <a name="event_incoming"></a>
 
 ### "incoming"

--- a/src/lib/receiver.js
+++ b/src/lib/receiver.js
@@ -211,10 +211,21 @@ function createReceiver (opts) {
     ])
   }
 
+  /**
+   * Disconnect from the ledger and stop listening for events.
+   *
+   * @return {Promise.<null>} Resolves when the receiver is disconnected.
+   */
+  function stopListening () {
+    client.removeListener('incoming_prepare', autoFulfillConditions)
+    return client.disconnect()
+  }
+
   return Object.assign(eventEmitter, {
     getAddress,
     createRequest,
-    listen
+    listen,
+    stopListening
   })
 }
 

--- a/src/lib/sender.js
+++ b/src/lib/sender.js
@@ -147,9 +147,11 @@ function createSender (opts) {
             if (transfer.executionCondition === paymentParams.executionCondition) {
               debug('outgoing transfer fulfilled', fulfillment, transfer)
               clearTimeout(transferTimeout)
+              client.removeListener('outgoing_fulfill', fulfillmentListener)
               resolve(fulfillment)
             }
           }
+          // TODO disconnect from the client if there are no more listeners
           client.on('outgoing_fulfill', fulfillmentListener)
         })
       })

--- a/test/mocks/mockCore.js
+++ b/test/mocks/mockCore.js
@@ -19,6 +19,10 @@ class Client extends EventEmitter {
     return Promise.resolve()
   }
 
+  disconnect () {
+    return Promise.resolve()
+  }
+
   waitForConnection () {
     return Promise.resolve()
   }

--- a/test/receiverSpec.js
+++ b/test/receiverSpec.js
@@ -341,6 +341,15 @@ describe('Receiver Module', function () {
       })
     })
 
+    describe('stopListening', function () {
+      it('should remove listeners and disconnect the client', function () {
+        const spy = sinon.spy(this.client, 'disconnect')
+        this.receiver.stopListening()
+        expect(this.client.listeners('incoming_prepare')).to.have.lengthOf(0)
+        expect(spy).to.have.been.calledOnce
+      })
+    })
+
     describe('events', function () {
       beforeEach(function * () {
         yield this.receiver.listen()
@@ -381,7 +390,7 @@ describe('Receiver Module', function () {
               account: 'ilpdemo.blue.bob.someapp.requestid'
             }
           },
-          executionCondition: 'cc:0:3:JYlpv1MC5nAL-wTCLawUZJ34kGF8x5CyOxzfpDoXdEI:32'          
+          executionCondition: 'cc:0:3:JYlpv1MC5nAL-wTCLawUZJ34kGF8x5CyOxzfpDoXdEI:32'
         }))
         expect(emitted).to.be.true
       })


### PR DESCRIPTION
this is to help users of this library clean up when they no longer need the ILP client.
receiver.stopListening is an explicit command to remove the listeners and disconnect the underlying
client. for the sender, listeners should be removed once an outgoing payment is fulfilled or times
out.

resolves https://github.com/interledger/js-ilp/issues/36