### PR TITLE
Handle request amounts w/ too many decimal places and significant digits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules/
 /coverage/
 docs/*.intermediate.md
+*.log
+

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ of transfers paying for the payment requests created by the Receiver.
 | [opts.hmacKey] | <code>Buffer</code> | <code>crypto.randomBytes(32)</code> | 32-byte secret used for generating request conditions |
 | [opts.defaultRequestTimeout] | <code>Number</code> | <code>30</code> | Default time in seconds that requests will be valid for |
 | [opts.allowOverPayment] | <code>Boolean</code> | <code>false</code> | Allow transfers where the amount is greater than requested |
+| [opts.roundingMode] | <code>String</code> | <code></code> | Round request amounts with too many decimal places, possible values are "UP", "DOWN", "HALF_UP", "HALF_DOWN" as described in https://mikemcl.github.io/bignumber.js/#constructor-properties |
 | [opts.connectionTimeout] | <code>Number</code> | <code>10</code> | Time in seconds to wait for the ledger to connect |
 
 
@@ -260,10 +261,11 @@ Create a payment request
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| params.amount | <code>String</code> |  | Amount to request |
+| params.amount | <code>String</code> |  | Amount to request. It will throw an error if the amount has too many decimal places or significant digits, unless the receiver option roundRequestsAmounts is set |
 | [params.id] | <code>String</code> | <code>uuid.v4()</code> | Unique ID for the request (used to ensure conditions are unique per request) |
 | [params.expiresAt] | <code>String</code> | <code>30 seconds from now</code> | Expiry of request |
 | [params.data] | <code>Object</code> | <code></code> | Additional data to include in the request |
+| [params.roundingMode] | <code>String</code> | <code>receiver.roundingMode</code> | Round request amounts with too many decimal places, possible values are "UP", "DOWN", "HALF_UP", "HALF_DOWN" as described in https://mikemcl.github.io/bignumber.js/#constructor-properties |
 
 <a name="module_Receiver..createReceiver..listen"></a>
 

--- a/test/mocks/mockCore.js
+++ b/test/mocks/mockCore.js
@@ -13,7 +13,7 @@ class Client extends EventEmitter {
       getAccount: () => Promise.resolve(this.account),
       getInfo: () => ({
         scale: 2,
-        precision: 2
+        precision: 10
       }),
       isConnected: () => true,
       rejectIncomingTransfer: () => {

--- a/test/mocks/mockCore.js
+++ b/test/mocks/mockCore.js
@@ -11,6 +11,10 @@ class Client extends EventEmitter {
   getPlugin () {
     return {
       getAccount: () => Promise.resolve(this.account),
+      getInfo: () => ({
+        scale: 2,
+        precision: 2
+      }),
       isConnected: () => true,
       rejectIncomingTransfer: () => {
         this.rejected = true

--- a/test/receiverSpec.js
+++ b/test/receiverSpec.js
@@ -143,6 +143,22 @@ describe('Receiver Module', function () {
         }).to.throw('amount is required')
       })
 
+      it('should throw an error if the amount has more decimal places than the ledger supports', function () {
+        expect(() => {
+          this.receiver.createRequest({
+            amount: '10.001'
+          })
+        }).to.throw(/request amount has more decimal places than the ledger supports \(\d+\)/)
+      })
+
+      it('should throw an error if the amount has more significant digits than the ledger supports', function () {
+        expect(() => {
+          this.receiver.createRequest({
+            amount: '1000000000.1'
+          })
+        }).to.throw(/request amount has more significant digits than the ledger supports \(\d+\)/)
+      })
+
       it('should throw an error if expiresAt is invalid', function () {
         expect(() => {
           this.receiver.createRequest({

--- a/test/receiverSpec.js
+++ b/test/receiverSpec.js
@@ -218,6 +218,76 @@ describe('Receiver Module', function () {
         expect(request).to.not.have.keys('data')
       })
 
+      it('should round up request amounts with too many decimal places if receiver.roundingMode=UP', function * () {
+        const receiver = createReceiver({
+          client: this.client,
+          hmacKey: Buffer.from('+Xd3hhabpygJD6cen+R/eon+acKWvFLzqp65XieY8W0=', 'base64'),
+          roundingMode: 'UP'
+        })
+        yield receiver.listen()
+        const request = receiver.createRequest({
+          amount: '10.001'
+        })
+        expect(request.amount).to.equal('10.01')
+      })
+
+      it('should round down request amounts with too many decimal places if receiver.roundRequestAmounts=DOWN', function * () {
+        const receiver = createReceiver({
+          client: this.client,
+          hmacKey: Buffer.from('+Xd3hhabpygJD6cen+R/eon+acKWvFLzqp65XieY8W0=', 'base64'),
+          roundingMode: 'DOWN'
+        })
+        yield receiver.listen()
+        const request = receiver.createRequest({
+          amount: '10.001'
+        })
+        expect(request.amount).to.equal('10')
+      })
+
+      it('should round up request amounts with too many decimal places if roundingMode=UP for the payment request', function * () {
+        const request = this.receiver.createRequest({
+          amount: '10.001',
+          roundingMode: 'UP'
+        })
+        expect(request.amount).to.equal('10.01')
+      })
+
+      it('should round down request amounts with too many decimal places if roundingMode=DOWN for the payment request', function * () {
+        const request = this.receiver.createRequest({
+          amount: '10.001',
+          roundingMode: 'DOWN'
+        })
+        expect(request.amount).to.equal('10')
+      })
+
+      it('should give the roundingMode supplied in the createRequest params precedence over the one passed to createReceiver', function * () {
+        const receiver = createReceiver({
+          client: this.client,
+          hmacKey: Buffer.from('+Xd3hhabpygJD6cen+R/eon+acKWvFLzqp65XieY8W0=', 'base64'),
+          roundingMode: 'DOWN'
+        })
+        yield receiver.listen()
+        const request = receiver.createRequest({
+          amount: '10.001',
+          roundingMode: 'UP'
+        })
+        expect(request.amount).to.equal('10.01')
+      })
+
+      it('should throw an error if rounding would more than double the amount', function * () {
+        expect(() => this.receiver.createRequest({
+          amount: '0.004',
+          roundingMode: 'UP'
+        })).to.throw('rounding 0.004 UP would more than double it')
+      })
+
+      it('should throw an error if rounding would reduce the amount to zero', function * () {
+        expect(() => this.receiver.createRequest({
+          amount: '0.004',
+          roundingMode: 'DOWN'
+        })).to.throw('rounding 0.004 DOWN would reduce it to zero')
+      })
+
       it.skip('should generate the condition from the request details', function () {
 
       })
@@ -436,3 +506,4 @@ describe('Receiver Module', function () {
     })
   })
 })
+

--- a/test/receiverSpec.js
+++ b/test/receiverSpec.js
@@ -361,6 +361,22 @@ describe('Receiver Module', function () {
           // because we're instantiating an extra receiver there will actually be two events
           expect(results).to.contain('sent')
         })
+
+        it('should handle trailing zeros in the packet amount', function * () {
+          const request = this.receiver.createRequest({
+            amount: 1,
+            id: '22e315dc-3f99-4f89-9914-1987ceaa906d',
+            expiresAt: this.transfer.data.ilp_header.data.expires_at
+          })
+          const results = yield this.client.emitAsync('incoming_prepare', _.merge(this.transfer, {
+            data: {
+              ilp_header: {
+                amount: '1.00'
+              }
+            }
+          }))
+          expect(results).to.contain('sent')
+        })
       })
     })
 


### PR DESCRIPTION
By default it will throw an error if you try to create a payment request with an amount that has more decimal places or significant digits than the ledger supports.

Also adds the receiver option `roundRequestAmounts`, which can be set to `UP`, `DOWN`, `HALF_DOWN`, etc to round requests amounts with too many decimal places.

Resolves https://github.com/interledger/js-ilp/issues/17