### PR TITLE
feat: make payRequest idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Returns an ILP Sender to quote and pay for payment requests.
 | opts._plugin | <code>LedgerPlugin</code> |  | Ledger plugin used to connect to the ledger, passed to [ilp-core](https://github.com/interledger/js-ilp-core) |
 | opts | <code>Objct</code> |  | Plugin parameters, passed to [ilp-core](https://github.com/interledger/js-ilp-core) |
 | [opts.client] | <code>ilp-core.Client</code> | <code>create a new instance with the plugin and opts</code> | [ilp-core](https://github.com/interledger/js-ilp-core) Client, which can optionally be supplied instead of the previous options |
-| [opts.maxHoldDuration] | <code>Buffer</code> | <code>10</code> | Maximum time in seconds to allow money to be held for |
+| [opts.maxHoldDuration] | <code>Number</code> | <code>10</code> | Maximum time in seconds to allow money to be held for |
+| [opts.uuidSeed] | <code>Buffer</code> | <code>crypto.randomBytes(32)</code> | Seed to use for generating transfer UUIDs |
 
 
 * [~createSender(opts)](#module_Sender..createSender) ⇒ <code>Sender</code>
@@ -209,7 +210,7 @@ Quote a request from a receiver
 <a name="module_Sender..createSender..payRequest"></a>
 
 #### createSender~payRequest(paymentParams) ⇒ <code>Promise.&lt;String&gt;</code>
-Pay for a payment request
+Pay for a payment request. Uses a determinstic transfer id so that paying is idempotent (as long as ledger plugins correctly reject multiple transfers with the same id)
 
 **Kind**: inner method of <code>[createSender](#module_Sender..createSender)</code>  
 **Returns**: <code>Promise.&lt;String&gt;</code> - Resolves with the condition fulfillment  

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/interledger/js-ilp#readme",
   "dependencies": {
+    "aguid": "^1.0.4",
     "bignumber.js": "^2.4.0",
     "canonical-json": "0.0.4",
     "debug": "^2.2.0",
@@ -45,6 +46,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "co-mocha": "^1.1.2",
+    "custom-error-instance": "^2.1.1",
     "cz-conventional-changelog": "^1.1.6",
     "eslint": "^3.1.1",
     "eslint-config-standard": "^5.3.5",

--- a/src/lib/receiver.js
+++ b/src/lib/receiver.js
@@ -41,8 +41,11 @@ function createReceiver (opts) {
   const hmacKey = opts.hmacKey || crypto.randomBytes(32)
   const defaultRequestTimeout = opts.defaultRequestTimeout || 30
   const allowOverPayment = !!opts.allowOverPayment
-  const roundingMode = opts.roundingMode && opts.roundingMode.toUpperCase()
   const connectionTimeout = opts.connectionTimeout || 10
+  const roundingMode = opts.roundingMode && opts.roundingMode.toUpperCase()
+  if (roundingMode && !BigNumber.hasOwnProperty('ROUND_' + roundingMode)) {
+    throw new Error('invalid roundingMode: ' + opts.roundingMode)
+  }
   // the following details are set on listen
   let account
   let scale
@@ -72,7 +75,7 @@ function createReceiver (opts) {
     }
     const roundingMode = 'ROUND_' + roundDirection.toUpperCase()
     if (!BigNumber.hasOwnProperty(roundingMode)) {
-      throw new Error('invalid rounding mode: ' + roundDirection)
+      throw new Error('invalid roundingMode: ' + roundDirection)
     }
     const roundedAmount = amount.round(scale, BigNumber[roundingMode])
     debug('rounded amount ' + amount.toString() + ' ' + roundDirection + ' to ' + roundedAmount.toString())

--- a/test/mocks/mockCore.js
+++ b/test/mocks/mockCore.js
@@ -16,7 +16,8 @@ class Client extends EventEmitter {
       rejectIncomingTransfer: () => {
         this.rejected = true
         return Promise.resolve()
-      }
+      },
+      getFulfillment: () => 'cf:fulfillment'
     }
   }
 

--- a/test/receiverSpec.js
+++ b/test/receiverSpec.js
@@ -49,6 +49,22 @@ describe('Receiver Module', function () {
       }).to.throw('hmacKey must be 32-byte Buffer if supplied')
     })
 
+    it('should throw an error if the roundingMode is invalid', function () {
+      expect(() => createReceiver({
+        client: this.client,
+        hmacKey: Buffer.from('+Xd3hhabpygJD6cen+R/eon+acKWvFLzqp65XieY8W0=', 'base64'),
+        roundingMode: 'blah'
+      })).to.throw('invalid roundingMode: blah')
+    })
+
+    it('should accept lower case roundingMode', function () {
+      expect(() => createReceiver({
+        client: this.client,
+        hmacKey: Buffer.from('+Xd3hhabpygJD6cen+R/eon+acKWvFLzqp65XieY8W0=', 'base64'),
+        roundingMode: 'up'
+      })).to.not.throw(/.*/)
+    })
+
     it('should return an object that is an EventEmitter with the `createRequest` and `listen` functions', function () {
       const receiver = createReceiver({
         client: this.client,
@@ -166,6 +182,15 @@ describe('Receiver Module', function () {
             expiresAt: 'blah'
           })
         }).to.throw('expiresAt must be an ISO 8601 timestamp')
+      })
+
+      it('should throw an error if the roundingMode is invalid', function () {
+        expect(() => {
+          this.receiver.createRequest({
+            amount: 10,
+            roundingMode: 'blah'
+          })
+        }).to.throw('invalid roundingMode: blah')
       })
 
       it('should return a JSON object', function () {

--- a/test/senderSpec.js
+++ b/test/senderSpec.js
@@ -433,6 +433,25 @@ describe('Sender Module', function () {
         expect(fulfillmentStub).to.be.calledOnce
         expect(results).to.deep.equal(['fulfillment', 'fulfillment'])
       })
+
+      it('should reject if the payment is a duplicate but getting the fulfillment fails', function * () {
+        const DuplicateIdError = CustomError('DuplicateIdError', { message: 'Duplicate id' })
+
+        const stub = sinon.stub(this.client, 'sendQuotedPayment')
+        stub.rejects(DuplicateIdError('id has already been used'))
+        const fulfillmentStub = sinon.stub(this.client.plugin, 'getFulfillment')
+          .rejects(new Error('something bad happened'))
+
+        let error
+        try {
+          yield this.sender.payRequest(this.paymentParams)
+        } catch (e) {
+          error = e
+        }
+        expect(error.message).to.equal('something bad happened')
+        expect(stub).to.be.calledOnce
+        expect(fulfillmentStub).to.be.calledOnce
+      })
     })
   })
 })

--- a/test/senderSpec.js
+++ b/test/senderSpec.js
@@ -11,6 +11,7 @@ const expect = chai.expect
 const timekeeper = require('timekeeper')
 const _ = require('lodash')
 const mockRequire = require('mock-require')
+const CustomError = require('custom-error-instance')
 
 const createSender = require('../src/lib/sender').createSender
 const MockClient = require('./mocks/mockCore').Client
@@ -30,7 +31,8 @@ describe('Sender Module', function () {
   describe('createSender', function () {
     it('should return an object with the `quoteRequest` and `payRequest` functions', function () {
       const sender = createSender({
-        client: this.client
+        client: this.client,
+        uuidSeed: Buffer.from('f73e2739c0f0ff4c9b7cac6678c89a59ee6cb8911b39d39afbf2fef9e77bc9c3', 'hex')
       })
       expect(sender).to.be.a('object')
       expect(sender.quoteRequest).to.be.a('function')
@@ -64,7 +66,8 @@ describe('Sender Module', function () {
     beforeEach(function () {
       this.paymentParams = _.cloneDeep(paymentParams)
       this.sender = createSender({
-        client: this.client
+        client: this.client,
+        uuidSeed: Buffer.from('f73e2739c0f0ff4c9b7cac6678c89a59ee6cb8911b39d39afbf2fef9e77bc9c3', 'hex')
       })
     })
 
@@ -314,6 +317,18 @@ describe('Sender Module', function () {
         }
       })
 
+      it('should reject if client.sendQuotedPayment rejects', function * () {
+        const stub = sinon.stub(this.client, 'sendQuotedPayment')
+        stub.rejects(new Error('something went wrong'))
+        let error
+        try {
+          yield this.sender.payRequest(this.paymentParams)
+        } catch (e) {
+          error = e
+        }
+        expect(error.message).to.equal('something went wrong')
+      })
+
       it('should remove the listener on the client if the transfer times out', function * () {
         timekeeper.reset()
         const clock = sinon.useFakeTimers(0)
@@ -361,6 +376,64 @@ describe('Sender Module', function () {
         yield this.sender.payRequest(this.paymentParams)
         expect(this.client.listeners('outgoing_fulfill')).to.have.lengthOf(0)
       })
+
+      it('should use a deterministic transfer id to make payment idempotent', function * () {
+        const spy = sinon.spy(this.client, 'sendQuotedPayment')
+        this.sender.payRequest(this.paymentParams)
+        this.sender.payRequest(this.paymentParams)
+        yield Promise.resolve()
+        expect(spy).to.have.always.been.calledWithMatch({
+          uuid: 'a3ef0628-2427-4ed2-839d-e34861932b22'
+        })
+      })
+
+      it('should return the fulfillment even when the payment is a duplicate but the original has not yet been fulfilled', function * () {
+        const DuplicateIdError = CustomError('DuplicateIdError', { message: 'Duplicate id' })
+        const MissingFulfillmentError = CustomError('MissingFulfillmentError', { message: 'Missing fulfillment' })
+
+        const stub = sinon.stub(this.client, 'sendQuotedPayment')
+        stub.onFirstCall().resolves(new Promise((resolve) => {
+            setImmediate(() => this.client.emit('outgoing_fulfill', {
+              executionCondition: this.paymentParams.executionCondition
+            }, 'fulfillment'))
+            resolve()
+          }))
+        stub.onSecondCall().rejects(DuplicateIdError('id has already been used'))
+        const fulfillmentStub = sinon.stub(this.client.plugin, 'getFulfillment')
+          .rejects(MissingFulfillmentError('not yet fulfilled'))
+
+        const results = yield Promise.all([
+          this.sender.payRequest(this.paymentParams),
+          this.sender.payRequest(this.paymentParams)
+        ])
+        expect(stub).to.be.calledTwice
+        expect(fulfillmentStub).to.be.calledOnce
+        expect(results).to.deep.equal(['fulfillment', 'fulfillment'])
+      })
+
+      it('should return the fulfillment even when the payment is a duplicate and the original has already been fulfilled', function * () {
+        const DuplicateIdError = CustomError('DuplicateIdError', { message: 'Duplicate id' })
+
+        const stub = sinon.stub(this.client, 'sendQuotedPayment')
+        stub.onFirstCall().resolves(new Promise((resolve) => {
+            setImmediate(() => this.client.emit('outgoing_fulfill', {
+              executionCondition: this.paymentParams.executionCondition
+            }, 'fulfillment'))
+            resolve()
+          }))
+        stub.onSecondCall().rejects(DuplicateIdError('id has already been used'))
+        const fulfillmentStub = sinon.stub(this.client.plugin, 'getFulfillment')
+          .resolves('fulfillment')
+
+        const results = yield Promise.all([
+          this.sender.payRequest(this.paymentParams),
+          this.sender.payRequest(this.paymentParams)
+        ])
+        expect(stub).to.be.calledTwice
+        expect(fulfillmentStub).to.be.calledOnce
+        expect(results).to.deep.equal(['fulfillment', 'fulfillment'])
+      })
     })
   })
 })
+


### PR DESCRIPTION
uses a deterministic transfer uuid based on a sender secret and the condition to ensure that multiple calls to payRequest on the same sender with the same params will not submit two payments. a repeat payment will return the fulfillment of the original transfer.

resolves https://github.com/interledger/js-ilp/issues/40